### PR TITLE
Replace nuxt-link by anchor tag index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,12 +36,12 @@ const description = 'A robust color management tool for the modern age.';
             </h1>
 
             <div class="flex justify-center m-4 lg:justify-start">
-              <nuxt-link
+              <a
                 class="bg-color1 btn block font-gt-walsheim text-white hover:bg-white hover:text-color1"
-                to="/download/"
+                href="/download"
               >
                 Download free
-              </nuxt-link>
+              </a>
             </div>
           </div>
 


### PR DESCRIPTION
Fixed a minor problem that made the download buttom on the landing page unclickable.

Reference: 
https://docs.astro.build/en/guides/migrate-to-astro/from-nuxtjs/#nuxt-property-passing-to-astro